### PR TITLE
filtered action selection behavior valueset

### DIFF
--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -62,3 +62,4 @@ Alias: $cs-group-membership-basis = http://hl7.org/fhir/group-membership-basis
 
 Alias: $cs-action-code = http://terminology.hl7.org/CodeSystem/action-code
 Alias: $cs-common-process = http://hl7.org/fhir/uv/cpg/CodeSystem/cpg-common-process
+Alias: $cs-action-selection-behavior = http://hl7.org/fhir/action-selection-behavior

--- a/input/fsh/intervention/p-recommendation-plan.fsh
+++ b/input/fsh/intervention/p-recommendation-plan.fsh
@@ -38,6 +38,7 @@ Description: "Definition of an activity that is part of an intervention in the c
   * definition[x] 0..1 MS
   * definition[x] only canonical
   * definitionCanonical only Canonical(RecommendationAction)
+  * selectionBehavior from vs-action-selection-behavior-required (required)
 * action[drugAdministration]
   * code = $sct#432102000 "Administration of substance (procedure)"
   * definitionCanonical only Canonical(DrugAdministrationAction)

--- a/input/fsh/intervention/vs-action-selection-behavior.fsh
+++ b/input/fsh/intervention/vs-action-selection-behavior.fsh
@@ -1,0 +1,11 @@
+// Author: Gregor Lichtner @glichtner
+ValueSet: ActionSelectionBehaviorRequired
+Id: vs-action-selection-behavior-required
+Title: "Action Selection Behavior Required"
+Description: "Action selection behavior with only codes that require at least one action to be performed."
+* insert metadata(2022-11-28, #draft, 0.1.0)
+* insert cpg-computable-valueset
+* $cs-action-selection-behavior#all "All"
+* $cs-action-selection-behavior#exactly-one "Exactly One"
+* $cs-action-selection-behavior#at-most-one "At Most One"
+* $cs-action-selection-behavior#one-or-more "One or More"


### PR DESCRIPTION
- PlanDefinition.action.selectionBehavior: now disallowing codes that do
  not require at least one action to be taken, i.e. the following codes
  from ActionSelectionBehavior are now disallowed:
  - any ("from zero to all")
  - all-or-none